### PR TITLE
Fix workflow useradd case

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ jobs:
       packages: write
 ```
 
+The default behavior of the workflow provides arguments for use with the [useradd Dockerfile partial](https://github.com/rcwbr/dockerfile-partials/tree/main/useradd) for Codespaces user provisioning. These arguments must be forwarded to the `devcontainer-cache-build-initialize` script, e.g. via the `DEVCONTAINER_BUILD_ADDITIONAL_ARGS` variable:
+
+```bash
+# .devcontainer/initialize
+
+export DEVCONTAINER_BUILD_ADDITIONAL_ARGS="$@"
+curl https://raw.githubusercontent.com/rcwbr/devcontainer-cache-build/0.1.0/devcontainer-cache-build-initialize | bash
+```
+
 ## Contributing
 
 ### CI/CD


### PR DESCRIPTION
Closes #7 

> ## What
> 
> Fix cache population workflow issue with default usage resulting in the [useradd layer](https://github.com/rcwbr/dockerfile-partials/tree/main/useradd) producing this error:
> 
> ```bash
> #29 [useradd base 1/2] RUN groupadd --gid 0 runner     && useradd --uid 0 --gid 0 --gid 800 -m runner     && apt-get update     && apt-get install -y sudo     && echo runner ALL=(root) NOPASSWD:ALL > /etc/sudoers.d/runner     && chmod 0440 /etc/sudoers.d/runner
> #29 0.096 groupadd: GID '0' already exists
> #29 ERROR: process "/bin/sh -c groupadd --gid $USER_GID $USER     && useradd --uid $USER_UID --gid $USER_GID $EXTRA_GID_ARGS -m $USER     && apt-get update     && apt-get install -y sudo     && echo $USER ALL=\\(root\\) NOPASSWD:ALL > /etc/sudoers.d/$USER     && chmod 0440 /etc/sudoers.d/$USER" did not complete successfully: exit code: 4
> 
> #30 [docker-client] exporting cache to registry
> #30 preparing build cache for export 0.2s done
> #30 CANCELED
> ```
> 
> ## Why
> 
> Documented workflow usage should be compatible with expected layers
> 
> ## How
> 
> Adjust README content