### PR TITLE
Lock image and layer timestamps

### DIFF
--- a/devcontainer-cache-build-initialize
+++ b/devcontainer-cache-build-initialize
@@ -118,6 +118,7 @@ DEVCONTAINER_DEFINITION_FILES="${whitespace_strip_array[@]}"
 ###### Execute build ######
 
 PREVIOUS_BUILDER_NAME=$(docker builder inspect | grep Name | head -1 | awk -F " " '{print $NF}')
+export SOURCE_DATE_EPOCH=1731797200 # Specify a static value for image and layer timestamps
 
 # Set up docker-container builder
 docker builder rm initialize-builder || true


### PR DESCRIPTION
Closes #9 

> ## What
> 
> Resolve cache misses on matching image build configurations
> 
> ## Why
> 
> No difference to the build configuration should always result in cache hits
> 
> ## How
> 
> Leverage the `SOURCE_DATE_EPOCH` variable as [recommended for reproducible builds](https://docs.docker.com/build/ci/github-actions/reproducible-builds/)
> 