### PR TITLE
Leverage released python on whales version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM base_context
 
-# TODO remove custom python-on-whales install
-ADD https://github.com/rcwbr/python-on-whales.git#0.1.5 /tmp/python-on-whales
-RUN pip install /tmp/python-on-whales
-
 RUN --mount=type=bind,src=requirements.txt,dst=/tmp/requirements.txt \
   pip install -r /tmp/requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-on-whales==0.74.0
+python-on-whales==0.75.0
 GitPython==3.1.43

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-on-whales==0.75.0
+python-on-whales==0.75.1
 GitPython==3.1.43


### PR DESCRIPTION
Closes #13 

> ## What
> 
> Convert installation of Python-on-whales from fork package to upstream released version
> 
> ## Why
> 
> Bake remote definition support is now available from upstream, not just the fork
> 
> ## How
> 
> Remove the custom installation in the Dockerfile