### PR TITLE
fix registry authentication for codespace usage

### DIFF
--- a/.devcontainer/initialize
+++ b/.devcontainer/initialize
@@ -13,7 +13,6 @@ devcontainer_definition_files_arr=(
 )
 DEVCONTAINER_DEFINITION_FILES="${devcontainer_definition_files_arr[@]}"
 export DEVCONTAINER_DEFINITION_FILES
-export DEVCONTAINER_PREBUILD_SCRIPT=.devcontainer/devcontainer-prebuild
 export DEVCONTAINER_BUILD_ADDITIONAL_ARGS="remote_definition=https://github.com/rcwbr/dockerfile-partials.git#0.3.0"
 # If an argument is passed to this script, pass it to the build call
 if [[ -z $# ]]; then

--- a/.github/workflows/devcontainer-cache-build.yaml
+++ b/.github/workflows/devcontainer-cache-build.yaml
@@ -47,6 +47,4 @@ jobs:
           export DEVCONTAINER_CACHE_BUILD_OVERRIDE_UID="${{ inputs.build-context-uid }}"
           export DEVCONTAINER_CACHE_BUILD_OVERRIDE_USER_GID="${{ inputs.build-context-gid }}"
           export DEVCONTAINER_CACHE_BUILD_IMAGE="${{ inputs.devcontainer-cache-build-image-override }}"
-          export GITHUB_USER=${{ github.actor }}
-          export DEVCONTAINER_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           ./.devcontainer/initialize ${{ inputs.initialize-args }}

--- a/README.md
+++ b/README.md
@@ -150,18 +150,11 @@ Configuring the `devcontainer-cache-build-initialize` script with a plain image 
 
 1. Create a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with [`write:packages` scope](https://docs.github.com/en/codespaces/reference/allowing-your-codespace-to-access-a-private-registry#publishing-a-package-from-a-codespace) for the repository to which the image belongs.
 1. Add the token as a [Codespace secret](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-your-account-specific-secrets-for-github-codespaces#adding-a-secret), to the repository to which the Codespaces environment belongs.
-1. [Use the secret variable to `docker login`](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic) in the Codespace environment by adding a login command to the devcontainer [prebuild script](#initialize-script-prebuild-file-usage), keeping in mind the `DEVCONTAINER_HOST_` prefix that will be applied by the initialize script.
-1. Set the `DEVCONTAINER_PREBUILD_SCRIPT` to the path of the devcontainer prebuild script in advance of the `curl` to the intialize script, e.g.:
-```bash
-# .devcontainer/devcontainer-prebuild
+  1. Name the variable for the token secret as `[prefix for your repo]_CONTAINER_REGISTRY_PASSWORD`
+1. Create another secret with the same name prefix but for the username `[prefix for your repo]_CONTAINER_REGISTRY_USER`, with the value set to your GitHub username
+1. Create another secret with the same name prefix called `[prefix for your repo]_CONTAINER_REGISTRY_SERVER`, with the value set to `ghcr.io`
 
-echo $DEVCONTAINER_HOST_DEVCONTAINER_CACHE_BUILD_DEVCONTAINER_INITIALIZE | docker login ghcr.io --username $DEVCONTAINER_HOST_GITHUB_USER --password-stdin
-
-# .devcontainer/initialize
-...
-export DEVCONTAINER_PREBUILD_SCRIPT=.devcontainer/devcontainer-prebuild
-curl https://raw.githubusercontent.com/rcwbr/devcontainer-cache-build/0.2.1/devcontainer-cache-build-initialize | bash
-```
+These are [automatically applied by GitHub](https://docs.github.com/en/codespaces/reference/allowing-your-codespace-to-access-a-private-registry#accessing-images-stored-in-other-registries) to authenticate in a Codespace. This is necessary because [other secrets are not accessible during Codespace image build](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-your-account-specific-secrets-for-github-codespaces#using-secrets).
 
 ### GitHub Actions workflow
 
@@ -175,8 +168,6 @@ jobs:
     permissions:
       packages: write
 ```
-
-> :warning: To avoid 403 Forbidden errors in the workflow, the [prebuild script](#initialize-script-prebuild-file-usage) must authenticate to GitHub Container Registry using `GITHUB_USER` and `DEVCONTAINER_GITHUB_TOKEN`, e.g. `echo $DEVCONTAINER_HOST_DEVCONTAINER_GITHUB_TOKEN | docker login ghcr.io --username $DEVCONTAINER_HOST_GITHUB_USER --password-stdin`
 
 The default behavior of the workflow provides arguments for use with the [useradd Dockerfile partial](https://github.com/rcwbr/dockerfile-partials/tree/main/useradd) for Codespaces user provisioning. These arguments must be forwarded to the `devcontainer-cache-build-initialize` script, e.g. via the `DEVCONTAINER_BUILD_ADDITIONAL_ARGS` variable:
 

--- a/devcontainer-cache-build-initialize
+++ b/devcontainer-cache-build-initialize
@@ -47,5 +47,6 @@ docker run \
   -e DEVCONTAINER_PREBUILD_SCRIPT \
   -e DEVCONTAINER_PUSH_IMAGE \
   -e DEVCONTAINER_REGISTRY \
+  -e DOCKER_CONFIG_JSON="$(cat ~/.docker/config.json)" \
   --env-file <(env | sed 's/^/DEVCONTAINER_HOST_/') \
   "$DEVCONTAINER_CACHE_BUILD_IMAGE"

--- a/devcontainer-cache-build-initialize.py
+++ b/devcontainer-cache-build-initialize.py
@@ -4,9 +4,10 @@ import json
 import re
 import subprocess
 from os import environ as env
+from os import getcwd as getcwd
 
 from python_on_whales import docker
-from git import Repo
+from git import Repo, GitConfigParser
 
 INITIALIZE_BUILDER_NAME = "initialize-builder"
 DEVCONTAINER_HOST_ENV_VAR_PREFIX = "DEVCONTAINER_HOST_"
@@ -89,8 +90,11 @@ DEVCONTAINER_DEFINITION_FILES = (
 )
 
 REPO = Repo(".")
+# Configure git to ignore ownership of the current directory
+REPO.config_writer(config_level='global').set_value("safe", "directory", getcwd())
+# Get the branch name unless in detached head state
+GIT_BRANCH = str(REPO.head.commit) if REPO.head.is_detached else str(REPO.head.ref)
 # Replace any non-alphanumeric (or underscore) characters in the branch names with dashes
-GIT_BRANCH = str(REPO.head.ref)
 GIT_BRANCH_SANITIZED = sanitize_ref(GIT_BRANCH)
 DEVCONTAINER_DEFAULT_BRANCH_NAME_SANITIZED = sanitize_ref(DEVCONTAINER_DEFAULT_BRANCH_NAME)
 

--- a/devcontainer-cache-build-initialize.py
+++ b/devcontainer-cache-build-initialize.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 from os import environ as env
 from os import getcwd as getcwd
+from pathlib import Path
 
 from python_on_whales import docker
 from git import Repo, GitConfigParser
@@ -172,6 +173,36 @@ DEVCONTAINER_CACHE_TOS = docker_destination_list_from_env_var(
     }]
   )
 )
+
+
+###### Prepare Docker client credentials ######
+
+DOCKER_CONFIG_JSON = env.get("DOCKER_CONFIG_JSON")
+if DOCKER_CONFIG_JSON is not None:
+  try:
+    print("Loading Docker config JSON from env var")
+    docker_config_content = json.loads(DOCKER_CONFIG_JSON)
+    docker_config_folder = Path(Path.home(), ".docker")
+    docker_config_folder.mkdir(exist_ok=True)
+    docker_config_filename = Path(docker_config_folder, "config.json")
+
+    if docker_config_filename.exists() and docker_config_filename.is_file():
+      print(f"Docker config file {docker_config_filename} exists, will merge config content")
+      with open(docker_config_filename, "r") as docker_config_file:
+        try:
+          docker_config_content = json.load(docker_config_file) | docker_config_content
+        except ValueError:
+          print(f"Invalid JSON content in {docker_config_filename}: {docker_config_file.read()}")
+
+    with open(docker_config_filename, "w") as docker_config_file:
+      print(f"Writing Docker config JSON to file {docker_config_filename}")
+      print(json.dumps(docker_config_content, indent=4))
+      json.dump(docker_config_content, docker_config_file, indent=4)
+
+  except ValueError:
+    print(f"Invalid JSON content for DOCKER_CONFIG_JSON: {DOCKER_CONFIG_JSON}")
+else:
+  print(f"No value set for DOCKER_CONFIG_JSON")
 
 
 ###### Execute pre-build script ######


### PR DESCRIPTION
Closes #15 

> ## What
> 
> Replace existing authentication method for devcontainer cache registry.
> 
> 1. Document process to create a token for registry access and apply to Codespace secrets with the correct `_CONTAINER_REGISTRY` syntax
> 1. Forward `~/.docker/config.json` auth as this is established in the Codespace build environment based on the available secrets, while those secrets are not forwarded to the build environment
> 1. Handle authentication from GitHub Actions (i.e. by `GITHUB_TOKEN`) by default vs. by initialize prebuild script
> 
> ## Why
> 
> Codespace secrets are [not available at initialize/image build time](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-your-account-specific-secrets-for-github-codespaces#using-secrets)
> 
> > Development environment secrets cannot be used… during codespace build time (that is, within a Dockerfile or custom entry point).
> 
> [And seamless registry authentication can only pull vs. push](https://docs.github.com/en/codespaces/reference/allowing-your-codespace-to-access-a-private-registry#publishing-a-package-from-a-codespace)
> 
> > Seamless access from a codespace to a registry is limited to pulling packages. If you want to publish a package from inside a codespace, you must use a personal access token (classic) with the `write:packages` scope
> 
> ## How
> 
> Using the [Codespaces private registry authentication pattern](https://docs.github.com/en/codespaces/reference/allowing-your-codespace-to-access-a-private-registry#accessing-images-stored-in-other-registries)
> > You can define secrets to allow GitHub Codespaces to access container image registries other than GitHub's Container registry. If you are accessing a container image from a registry that doesn't support seamless access, GitHub Codespaces checks for the presence of three secrets, which define the server name, username, and personal access token for a registry. If these secrets are found, GitHub Codespaces will make the registry available inside your codespace.
> > ```
> > <*>_CONTAINER_REGISTRY_SERVER
> > <*>_CONTAINER_REGISTRY_USER
> > <*>_CONTAINER_REGISTRY_PASSWORD
> > ```
> > You can store secrets at the user, repository, or organization-level, allowing you to share them securely between different codespaces