### PR TITLE
Output image metadata from ci workflow

### DIFF
--- a/.github/workflows/devcontainer-cache-build.yaml
+++ b/.github/workflows/devcontainer-cache-build.yaml
@@ -42,9 +42,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build devcontainer cache
+        env:
+          DEVCONTAINER_PUSH_IMAGE: true
+          DEVCONTAINER_CACHE_BUILD_OVERRIDE_USER: ${{ inputs.build-context-user }}
+          DEVCONTAINER_CACHE_BUILD_OVERRIDE_UID: ${{ inputs.build-context-uid }}
+          DEVCONTAINER_CACHE_BUILD_OVERRIDE_USER_GID: ${{ inputs.build-context-gid }}
+          DEVCONTAINER_CACHE_BUILD_IMAGE: ${{ inputs.devcontainer-cache-build-image-override }}
         run: |
-          export DEVCONTAINER_CACHE_BUILD_OVERRIDE_USER="${{ inputs.build-context-user }}"
-          export DEVCONTAINER_CACHE_BUILD_OVERRIDE_UID="${{ inputs.build-context-uid }}"
-          export DEVCONTAINER_CACHE_BUILD_OVERRIDE_USER_GID="${{ inputs.build-context-gid }}"
-          export DEVCONTAINER_CACHE_BUILD_IMAGE="${{ inputs.devcontainer-cache-build-image-override }}"
           ./.devcontainer/initialize ${{ inputs.initialize-args }}

--- a/devcontainer-cache-build-initialize.py
+++ b/devcontainer-cache-build-initialize.py
@@ -308,8 +308,16 @@ if DEVCONTAINER_DEFINITION_TYPE.lower() == "build":
   )
 elif DEVCONTAINER_DEFINITION_TYPE.lower() == "bake":
   # Docker bake case
-  print(json.dumps(docker.buildx.bake(
+  bake_json = json.dumps(docker.buildx.bake(
     print=True,
     **bake_params
-  ), indent=2))
+  ), indent=2)
+  print(bake_json)
+
+  # In CI, write the bake config to GitHub output
+  if env.get("CI", "false").lower() in ["true", "t", "yes", "y", "1"]:
+    with open(env.get("GITHUB_OUTPUT"), "a") as gh_output:
+      gh_output.write(f"metadata={bake_json}")
+
+  # Execute bake build
   docker.buildx.bake(**bake_params)


### PR DESCRIPTION
Closes #17 

> ## What
> 
> Output the devcontainer image from the CI workflow
> 
> ## Why
> 
> Subsequent CI jobs may require operating within the devcontainer image
> 
> ## How
> 
> Inject registry output for the final layer, and output the image reference as a [job output param](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter)