### PR TITLE
Support bake config with no-output targets for pre-pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Configuring the `devcontainer-cache-build-initialize` script with a plain image 
 
 These are [automatically applied by GitHub](https://docs.github.com/en/codespaces/reference/allowing-your-codespace-to-access-a-private-registry#accessing-images-stored-in-other-registries) to authenticate in a Codespace. This is necessary because [other secrets are not accessible during Codespace image build](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-your-account-specific-secrets-for-github-codespaces#using-secrets).
 
+### GHCR registry setup
+
+If using GHCR as the `DEVCONTAINER_REGISTRY`, the addition of any layer to the devcontainer definition involves configuring a registry for it with appropriate access. This is best achieved by leveraging the [GitHub Actions workflow](#github-actions-workflow), as registry configuration is established automatically. To do this, simply open a PR that contains the layer addition, before trying to rebuild a devcontainer/Codespace with the layer addition. Otherwise, registries may be created as private and require a manual settings change to make them public.
+
 ### GitHub Actions workflow
 
 Leveraging the entire lifecycle of the devcontainer cache requires applying a CI/CD workflow to prepopulate cache. This may be achieved via the reusable workflow defined in `.github/workflows/devcontainer-cache-build.yaml`, e.g.:

--- a/devcontainer-cache-build-initialize.py
+++ b/devcontainer-cache-build-initialize.py
@@ -287,11 +287,12 @@ elif DEVCONTAINER_DEFINITION_TYPE.lower() == "bake":
   # Docker bake case
   bake_config = docker.buildx.bake(print=True, **bake_params)
   for target_name, target in bake_config["target"].items():
-    for pull_image in target["output"]:
-      if "ref" in dict_from_string(pull_image):
-        image_name = dict_from_string(pull_image)["ref"]
-        print(f"Pulling image for {target_name} cache population: {image_name}")
-        docker.pull(image_name)
+    if "output" in target:
+      for pull_image in target["output"]:
+        if "ref" in dict_from_string(pull_image):
+          image_name = dict_from_string(pull_image)["ref"]
+          print(f"Pulling image for {target_name} cache population: {image_name}")
+          docker.pull(image_name)
 
 
 ###### CI bake config output ######

--- a/devcontainer-cache-build-initialize.py
+++ b/devcontainer-cache-build-initialize.py
@@ -264,6 +264,7 @@ if DEVCONTAINER_DEFINITION_TYPE.lower() == "bake":
       "DEVCONTAINER_CACHE_FROMS": docker_destinations_to_string(DEVCONTAINER_CACHE_FROMS),
       "DEVCONTAINER_CACHE_TOS": docker_destinations_to_string(DEVCONTAINER_CACHE_TOS),
       "DEVCONTAINER_OUTPUTS": docker_destinations_to_string(DEVCONTAINER_OUTPUTS),
+      "GIT_BRANCH_SANITIZED": GIT_BRANCH_SANITIZED,
       # Add devcontainer host env vars to the bake config
       **devcontainer_host_env_vars   
     },


### PR DESCRIPTION
Closes #19 

> ## What
> 
> Cleanly handle cases of empty outputs in the list of Bake targets.
> 
> ## Why
> 
> To support referencing all listed devcontainer targets in the default Bake group, even if not all have specified outputs
> 
> ## How
> 
> Conditionalize logic for extracting pre-pull images from target outputs