### PR TITLE
Output bake config of all layers to github

### DIFF
--- a/.github/workflows/devcontainer-cache-build.yaml
+++ b/.github/workflows/devcontainer-cache-build.yaml
@@ -33,6 +33,9 @@ on:
       devcontainer-cache-image-config:
         description: "The Bake config of the (last layer of the) devcontainer image built by the workflow"
         value: ${{ jobs.devcontainer-cache-build.outputs.devcontainer-cache-image-config }}
+      devcontainer-cache-image-all_configs:
+        description: "The Bake configs of all layers of the devcontainer image built by the workflow"
+        value: ${{ jobs.devcontainer-cache-build.outputs.devcontainer-cache-image-all_configs }}
 jobs:
   devcontainer-cache-build:
     name: Populate devcontainer image cache
@@ -61,3 +64,4 @@ jobs:
     outputs:
       devcontainer-cache-image-ref: ${{ steps.build-devcontainer-cache.outputs.ref }}
       devcontainer-cache-image-config: ${{ steps.build-devcontainer-cache.outputs.config }}
+      devcontainer-cache-image-all_configs: ${{ steps.build-devcontainer-cache.outputs.all_configs }}

--- a/devcontainer-cache-build-initialize.py
+++ b/devcontainer-cache-build-initialize.py
@@ -318,6 +318,7 @@ if env.get("CI", "false").lower() in ["true", "t", "yes", "y", "1"] and DEVCONTA
   with open(GITHUB_OUTPUT, "a") as gh_output:
     gh_output.write(f"ref={final_image_output}\n")
     gh_output.write(f"config={final_image_config}\n")
+    gh_output.write(f"all_configs={bake_config}\n")
 
 
 ###### Execute the build ######

--- a/devcontainer-cache-build-initialize.py
+++ b/devcontainer-cache-build-initialize.py
@@ -307,7 +307,7 @@ if env.get("CI", "false").lower() in ["true", "t", "yes", "y", "1"] and DEVCONTA
   final_image_output = ([
     output_dict["name"]
     for output_dict in final_image_output_dicts
-    if "name" in output_dict and "push" in output_dict and output_dict["push"]
+    if "name" in output_dict
   ] + [
     output_dict["ref"]
     for output_dict in final_image_output_dicts


### PR DESCRIPTION
Closes #21 

> ## What
> 
> Export bake configs for all layers, not just final
> 
> ## Why
> 
> Tool images and others may be required by later GHA jobs
> 
> ## How
> 
> Add entry to GITHUB_OUTPUTS