### PR TITLE
Restore workflow execution for tag pushes

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
     tags:
+      - '*'
   pull_request:
 jobs:
   build-docker-image:


### PR DESCRIPTION
Closes #26 

> ## What
> 
> Restore workflow executions for tag push events
> 
> ## Why
> 
> Tag push events are the primary context for release image publishing
> 
> ## How
> 
> Change the workflow trigger conditions