### PR TITLE
fix: cache refs in pull_request workflows

### DIFF
--- a/.github/workflows/devcontainer-cache-build.yaml
+++ b/.github/workflows/devcontainer-cache-build.yaml
@@ -44,7 +44,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v5.0.0
+        with:
+          # Use the PR branch (if applicable) instead of its merge branch
+          ref: ${{ github.head_ref || github.ref }}
       - name: GHCR Login
         uses: docker/login-action@v3.3.0
         with:


### PR DESCRIPTION
Closes #35 

> ## What
> 
> Correct `cache_to`/`cache_from` refs to point to the branch name instead of commit hashes in the case of `pull_request` workflows.
> 
> ## Why
> 
> To cache successfully across workflow runs in the same pull request branch.
> 
> ## How
> 
> Adjust the workflow checkout configuration to avoid detached head state (see [action usage](https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-to-a-pr-using-the-built-in-token)).