### PR TITLE
feat: add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,19 @@
+---
+name: Bug
+about: Bug template
+labels: bug
+assignees: rcwbr
+
+---
+
+## Expected behavior
+
+
+
+## Observed behavior
+
+
+
+## Proposed resolution
+
+(optional)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.md.md
+++ b/.github/ISSUE_TEMPLATE/feature.md.md
@@ -1,0 +1,19 @@
+---
+name: Feature
+about: Feature template
+labels: enhancement
+assignees: rcwbr
+
+---
+
+## What
+
+
+
+## Why
+
+
+
+## How
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+Closes #issue reference
+
+> Copy issue contents for reference

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
   rev: 0.7.17
   hooks:
   - id: mdformat
+    exclude: '.github/ISSUE_TEMPLATE/.*\.md$'
     additional_dependencies:
     - mdformat-black
     - mdformat-config
@@ -45,6 +46,7 @@ repos:
   - id: check-yaml
   - id: detect-private-key
   - id: end-of-file-fixer
+    exclude: '.github/ISSUE_TEMPLATE/.*\.md$'
   - id: forbid-submodules
   - id: mixed-line-ending
   - id: pretty-format-json


### PR DESCRIPTION
Closes #37 

> ## What
> 
> Add issue and PR templates to the repo.
> 
> ## Why
> 
> For consistency and convenience in development operations.
> 
> ## How
> 
> md/yaml files.