### PR TITLE
fix: remove docker config print

### DIFF
--- a/devcontainer-cache-build-initialize.py
+++ b/devcontainer-cache-build-initialize.py
@@ -228,7 +228,6 @@ if DOCKER_CONFIG_JSON is not None:
 
         with open(docker_config_filename, "w") as docker_config_file:
             print(f"Writing Docker config JSON to file {docker_config_filename}")
-            print(json.dumps(docker_config_content, indent=4))
             json.dump(docker_config_content, docker_config_file, indent=4)
 
     except ValueError:


### PR DESCRIPTION
Closes #34 

> ## What
> 
> Remove print of Docker config info.
> 
> ## Why
> 
> To prevent logging sensitive values.
> 
> ## How
> 
> Remove [this line](https://github.com/rcwbr/devcontainer-cache-build/blob/13cc8f658943e41514c33b75e28535e6e63fd86e/devcontainer-cache-build-initialize.py#L231C13-L231C63)